### PR TITLE
Http mock extensions

### DIFF
--- a/canaveral-mocks/canaveral-downstream-http-mock/src/main/java/pl/codewise/canaveral/mock/http/HttpNoDepsMockProvider.java
+++ b/canaveral-mocks/canaveral-downstream-http-mock/src/main/java/pl/codewise/canaveral/mock/http/HttpNoDepsMockProvider.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -91,7 +92,7 @@ public class HttpNoDepsMockProvider implements MockProvider {
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         mockServer.stop(0);
     }
 
@@ -171,6 +172,11 @@ public class HttpNoDepsMockProvider implements MockProvider {
         @Override
         public void addRule(HttpRequestRule request, HttpResponseRule response) {
             rules.add(0, MockRule.create(request, response));
+        }
+
+        @Override
+        public void addRule(Predicate<HttpRawRequest> requestPredicate, HttpResponseRule response) {
+            rules.add(MockRule.create(requestPredicate, response));
         }
     }
 }

--- a/canaveral-mocks/canaveral-downstream-http-mock/src/main/java/pl/codewise/canaveral/mock/http/HttpRuleCreator.java
+++ b/canaveral-mocks/canaveral-downstream-http-mock/src/main/java/pl/codewise/canaveral/mock/http/HttpRuleCreator.java
@@ -1,6 +1,10 @@
 package pl.codewise.canaveral.mock.http;
 
+import java.util.function.Predicate;
+
 interface HttpRuleCreator {
 
     void addRule(HttpRequestRule request, HttpResponseRule response);
+
+    void addRule(Predicate<HttpRawRequest> requestPredicate, HttpResponseRule response);
 }

--- a/canaveral-mocks/canaveral-downstream-http-mock/src/main/java/pl/codewise/canaveral/mock/http/HttpRuleRepository.java
+++ b/canaveral-mocks/canaveral-downstream-http-mock/src/main/java/pl/codewise/canaveral/mock/http/HttpRuleRepository.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
 
 public class HttpRuleRepository implements HttpRuleCreator {
 
@@ -21,8 +22,13 @@ public class HttpRuleRepository implements HttpRuleCreator {
         rules.add(0, MockRule.create(request, response));
     }
 
+    @Override
+    public void addRule(Predicate<HttpRawRequest> requestPredicate, HttpResponseRule response) {
+        rules.add(MockRule.create(requestPredicate, response));
+    }
+
     public HttpRuleRepository removeRule(HttpRequestRule request) {
-        rules.removeIf(mockRule -> mockRule.getRequest().equals(request));
+        rules.removeIf(mockRule -> (mockRule.getRequest() != null) && mockRule.getRequest().equals(request));
         return this;
     }
 

--- a/canaveral-mocks/canaveral-downstream-http-mock/src/main/java/pl/codewise/canaveral/mock/http/MockRule.java
+++ b/canaveral-mocks/canaveral-downstream-http-mock/src/main/java/pl/codewise/canaveral/mock/http/MockRule.java
@@ -19,11 +19,15 @@ class MockRule {
     private final HttpRequestRule request;
     private final HttpResponseRule response;
 
-    private MockRule(Predicate<HttpRawRequest> condition, HttpRequestRule request,
+    private MockRule(Predicate<HttpRawRequest> requestPredicate, HttpRequestRule request,
             HttpResponseRule response) {
-        this.condition = condition;
+        this.condition = requestPredicate;
         this.request = request;
         this.response = response;
+    }
+
+    static MockRule create(Predicate<HttpRawRequest> requestPredicate, HttpResponseRule response) {
+        return new MockRule(requestPredicate, null, response);
     }
 
     static MockRule create(HttpRequestRule ruleRequest, HttpResponseRule ruleResponse) {


### PR DESCRIPTION
Ability to provide custom request predicate as rule,  ability to mock based on payload (body).